### PR TITLE
Use log4j to output run messages for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ Mix in the `HiveSupport` trait in `import au.com.cba.omnia.thermometer.hive.Hive
 support for hive and, in particular, set up a separate warehouse directory and metadata database per
 test and provide the right `HiveConf`.
 
+log verbosity
+-------------
+
+The verbosity of the logging messages from Thermometer and Hadoop can be configured by adding a
+`log4j.properties` file. Please find an example in
+[core/src/main/resources/log4j.properties](core/src/main/resources/log4j.properties).
 
 ongoing work
 ------------

--- a/core/src/main/resources/log4j.properties
+++ b/core/src/main/resources/log4j.properties
@@ -2,3 +2,4 @@ log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.rootLogger=ERROR,console
 hadoop.root.logger=ERROR,console
+log4j.category.au.com.cba.omnia.thermometer=INFO

--- a/core/src/main/scala/au/com/cba/omnia/thermometer/core/ThermometerSpec.scala
+++ b/core/src/main/scala/au/com/cba/omnia/thermometer/core/ThermometerSpec.scala
@@ -23,6 +23,8 @@ import com.twitter.scalding.{Job, TypedPipe, Args}
 
 import org.apache.commons.io.FileUtils
 
+import org.apache.log4j.LogManager
+
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.specs2._
@@ -89,11 +91,12 @@ abstract class ThermometerSpec extends Specification
     def run:Option[scalaz.\/[String,Throwable]]
     
     def runsOk: Result = {
-      println("")
-      println("")
-      println(s"============================   Running test with work directory <$dir>  ============================")
-      println("")
-      println("")
+      val log = LogManager.getLogger(getClass)
+      log.info("")
+      log.info("")
+      log.info(s"============================   Running test with work directory <$dir>  ============================")
+      log.info("")
+      log.info("")
 
       run match {
         case None =>

--- a/core/src/main/scala/au/com/cba/omnia/thermometer/tools/ExecutionSupport.scala
+++ b/core/src/main/scala/au/com/cba/omnia/thermometer/tools/ExecutionSupport.scala
@@ -22,6 +22,8 @@ import com.twitter.scalding._
 
 import org.apache.hadoop.mapred.JobConf
 
+import org.apache.log4j.LogManager
+
 import org.specs2.Specification
 import org.specs2.execute.{Result, Success => SpecsSuccess, Failure => SpecsFailure, FailureException}
 import org.specs2.execute.StandardResults.success
@@ -33,11 +35,12 @@ import au.com.cba.omnia.thermometer.fact.Fact
 trait ExecutionSupport extends FieldConversions with HadoopSupport { self: Specification =>
   /** Executes the provided execution with an optional map of arguments. */
   def execute[T](execution: Execution[T], args: Map[String, List[String]] = Map.empty): Try[T] = {
-    println("")
-    println("")
-    println(s"============================   Running execution test with work directory <$dir>  ============================")
-    println("")
-    println("")
+    val log = LogManager.getLogger(getClass)
+    log.info("")
+    log.info("")
+    log.info(s"============================   Running execution test with work directory <$dir>  ============================")
+    log.info("")
+    log.info("")
 
     val mode   = Hdfs(false, jobConf)
     val a      = Mode.putMode(mode, new Args(args + (("hdfs", List.empty))))


### PR DESCRIPTION
This PR changes the messages that are output during tests so that they use log4j logging instead of raw `println` statements.