### PR TITLE
Fixes bug in PathFactoids that can cause test failures to be ignored.

### DIFF
--- a/core/src/main/scala/au/com/cba/omnia/thermometer/fact/PathFact.scala
+++ b/core/src/main/scala/au/com/cba/omnia/thermometer/fact/PathFact.scala
@@ -17,7 +17,7 @@ package au.com.cba.omnia.thermometer.fact
 import org.apache.hadoop.fs.{FileSystem, Path, RemoteIterator}
 
 import org.specs2.execute.Result
-import org.specs2.matcher.ThrownExpectations
+import org.specs2.matcher.MustThrownExpectations
 import org.specs2.matcher.MustMatchers._
 
 import scalaz._, Scalaz._
@@ -34,7 +34,7 @@ case class PathFact(path: Path) {
 
 case class PathFactoid(run: (Context, Path) => Result)
 
-object PathFactoids extends ThrownExpectations {
+object PathFactoids extends MustThrownExpectations {
   def conditional(cond: (Context, Path) => Boolean)(message: Path => String): PathFactoid =
     PathFactoid((context, path) => if (cond(context, path)) ok.toResult else failure(message(path)))
 

--- a/core/src/test/scala/au/com/cba/omnia/thermometer/fact/PathFactSpec.scala
+++ b/core/src/test/scala/au/com/cba/omnia/thermometer/fact/PathFactSpec.scala
@@ -1,0 +1,35 @@
+//   Copyright 2014 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package au.com.cba.omnia.thermometer.fact
+
+import au.com.cba.omnia.thermometer.core.ThermometerSpec
+
+object PathFactoidsSpec extends ThermometerSpec { def is = s2"""
+PathFactoids
+============
+
+  `checkEquality` correctly handles test failures where multiple expectations are checked
+    This actually tests that the test fails so we use pending until fixed
+    to turn it into a pending. If the test passes it will actually be turned
+    into a failure.                                                            ${thrownExpectations.pendingUntilFixed}
+
+"""
+
+  def thrownExpectations = {
+    PathFactoids.checkEquality(List(1, 2), List(3, 4), identity[Int], "error message")
+
+    2 must_== 2
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.0.0"
+version in ThisBuild := "1.0.1"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
`checkEquality`in `PathFactoids` uses `must` to create a Specs2
`Result`. For this to create a failure when using `ThrownExpecations`
`PathFactoids` needs to extend `MustThrownExpecations`. This affects all
the `records` functions.

This fixes #46.