### PR TITLE
Custom configuration for Execution-based tests

### DIFF
--- a/core/src/main/scala/au/com/cba/omnia/thermometer/tools/ExecutionSupport.scala
+++ b/core/src/main/scala/au/com/cba/omnia/thermometer/tools/ExecutionSupport.scala
@@ -33,8 +33,30 @@ import au.com.cba.omnia.thermometer.fact.Fact
 
 /** Adds testing support for scalding execution monad by setting up a test `Config` and `Mode`.*/
 trait ExecutionSupport extends FieldConversions with HadoopSupport { self: Specification =>
-  /** Executes the provided execution with an optional map of arguments. */
-  def execute[T](execution: Execution[T], args: Map[String, List[String]] = Map.empty, extraConfig: Config = Config.empty): Try[T] = {
+  /** 
+   * Executes the provided execution.
+   * 
+   * The provided `Execution` is run in HDFS mode, using supplied arguments and optional additional
+   * configuration. The method returns a `Try[T]` containing the result after waiting for the
+   * execution to finish.
+   * 
+   * `extraConfig` should be used with caution since it can potentially override important
+   * parameters of the `Execution`, such as the mode and arguments. A useful purpose for
+   * `extraConfig` is to add custom serialization for the execution.
+   * 
+   * @tparam T type of the execution (the type of its result)
+   * @param execution execution to execute
+   * @param args arguments passed to `Execution.run` (placed in the Scalding `Args` 
+   *        variable of the `Config`)
+   * @param extraConfig extra configuration passed to `Execution.run` (appended to the
+   *        `Config` that would otherwise be used using the `++` method)
+   * @return `Try[T]` containing the result of waiting for the execution to complete
+   */
+  def execute[T](
+    execution: Execution[T],
+    args: Map[String, List[String]] = Map.empty,
+    extraConfig: Config = Config.empty
+  ): Try[T] = {
     val log = LogManager.getLogger(getClass)
     log.info("")
     log.info("")
@@ -54,12 +76,30 @@ trait ExecutionSupport extends FieldConversions with HadoopSupport { self: Speci
   }
 
   /**
-    * Checks that the provided execution executed successfully.
-    * 
-    * It ignores the result of the execution.
-    * Takes an optional map of arguments and any extra configuration parameters.
-    */
-  def executesOk(execution: Execution[_], args: Map[String, List[String]] = Map.empty, extraConfig: Config = Config.empty): Result = {
+   * Checks that the provided execution executed successfully.
+   * 
+   * The value produced by the execution is ignored.
+   * 
+   * The provided `Execution` is run in HDFS mode, using supplied arguments and optional additional
+   * configuration. Any return value from the execution is discarded.
+   * 
+   * `extraConfig` should be used with caution since it can potentially override important
+   * parameters of the `Execution`, such as the mode and arguments. A useful purpose for
+   * `extraConfig` is to add custom serialization for the execution.
+   * 
+   * @tparam T type of the execution (the type of its result)
+   * @param execution execution to execute
+   * @param args arguments passed to `Execution.run` (placed in the Scalding `Args` 
+   *        variable of the `Config`)
+   * @param extraConfig extra configuration passed to `Execution.run` (appended to the
+   *        `Config` that would otherwise be used using the `++` method)
+   * @return `Result` of running the execution (discarding the value produced)
+   */
+  def executesOk(
+    execution: Execution[_],
+    args: Map[String, List[String]] = Map.empty,
+    extraConfig: Config = Config.empty
+  ): Result = {
     execute(execution, args, extraConfig) match {
       case Success(x) => SpecsSuccess()
       case Failure(t) => {
@@ -72,11 +112,29 @@ trait ExecutionSupport extends FieldConversions with HadoopSupport { self: Speci
   }
 
   /**
-    * Checks that the provided execution executed successfully and returns the result
-    * 
-    * Takes an optional map of arguments.
-    */
-  def executesSuccessfully[T](execution: Execution[T], args: Map[String, List[String]] = Map.empty, extraConfig: Config = Config.empty): T = {
+   * Checks that the provided execution executed successfully and returns the value produced.
+   * 
+   * The provided `Execution` is run in HDFS mode, using supplied arguments and optional additional
+   * configuration. The method returns the value of the execution if it was successful, and throws a
+   * `FailureException` if it faield.
+   * 
+   * `extraConfig` should be used with caution since it can potentially override important
+   * parameters of the `Execution`, such as the mode and arguments. A useful purpose for
+   * `extraConfig` is to add custom serialization for the execution.
+   * 
+   * @tparam T type of the execution (the type of its result value)
+   * @param execution execution to execute
+   * @param args arguments passed to `Execution.run` (placed in the Scalding `Args` 
+   *        variable of the `Config`)
+   * @param extraConfig extra configuration passed to `Execution.run` (appended to the
+   *        `Config` that would otherwise be used using the `++` method)
+   * @return value produced by the execution
+   */
+  def executesSuccessfully[T](
+    execution: Execution[T],
+    args: Map[String, List[String]] = Map.empty,
+    extraConfig: Config = Config.empty
+  ): T = {
     execute(execution, args, extraConfig) match {
       case Success(x) => x
       case Failure(t) =>

--- a/core/src/test/scala/au/com/cba/omnia/thermometer/example/CustomSerializersSpec.scala
+++ b/core/src/test/scala/au/com/cba/omnia/thermometer/example/CustomSerializersSpec.scala
@@ -1,0 +1,108 @@
+//   Copyright 2014 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package au.com.cba.omnia.thermometer.example
+
+import scala.collection.immutable._
+
+import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.format.{DateTimeFormat}
+
+import com.esotericsoftware.kryo.Serializer
+
+import com.twitter.algebird.{Aggregator, Monoid}
+
+import com.twitter.chill._
+import com.twitter.chill.config.{Config => ChillConfig,
+                                 ConfiguredInstantiator => ChillConfiguredInstantiator}
+
+import com.twitter.scalding.{Config, TypedPsv}
+import com.twitter.scalding.typed.IterablePipe
+import com.twitter.scalding.serialization.KryoHadoop
+
+import au.com.cba.omnia.thermometer.core.Thermometer._
+import au.com.cba.omnia.thermometer.core.ThermometerSpec
+
+/**
+ * Demonstrates custom serializers attached to a Thermometer specification.
+ * 
+ * Ordinarily, JodaTime `DateTime` objects cannot be serialized by Scalding. It is possible to
+ * serialize them with a custom Kryo serializer. This example illustrates how this can be
+ * achieved, by passing a custom serializer as part of the job configuration.
+ */
+class CustomSerializersSpec extends ThermometerSpec { def is = s2"""
+
+Demonstration of an execution-based ThermometerSpec that relies on a custom Kryo serializer
+===========================================================================================
+
+  Verify that a custom serializer can participate in a test $usingCustomSerializer
+
+"""
+
+  import CustomSerializerSpec._
+
+  def usingCustomSerializer = {
+
+    // pass the register of extra serialziers to the execution job
+    val extraConfig =
+      Config.empty ++
+      Map(ChillConfiguredInstantiator.KEY -> classOf[CustomSerializerRegistration].getName)
+
+    // test pipe of DateTime objects, which can't be serialized properly without a custom
+    // serializer
+    val times: IterablePipe[DateTime] = IterablePipe(List(
+      yyyyMMdd.parseDateTime("20150101"),
+      yyyyMMdd.parseDateTime("20150602")
+    ))
+
+    // the execution just converts the DateTime objects back to Strings
+    val exec =
+      times
+        .map(yyyyMMdd.print)
+        .writeExecution(TypedPsv("customers"))
+
+    executesOk(exec, extraConfig = extraConfig)
+    expectations(
+      _.lines("customers" </> "part-*") must contain(allOf("20150101", "20150602"))
+    )
+  }
+
+}
+
+object CustomSerializerSpec {
+
+  val yyyyMMdd = DateTimeFormat.forPattern("yyyyMMdd")
+
+  // Custom serializer for Joda DateTime objects
+  class DateTimeSerializer extends Serializer[DateTime] {
+    def write(kryo: Kryo, o: Output, d: DateTime): Unit = {
+      o.writeLong(d.getMillis, true)
+      () // intentionally discard non-Unit value
+    }
+    def read(kryo: Kryo, i: Input, `type`: Class[DateTime]): DateTime = {
+      val millis = i.readLong(true)
+      new DateTime(millis, DateTimeZone.forID("Australia/Sydney"))
+    }
+  }
+
+  // Register the custom serializer
+  class CustomSerializerRegistration(config: ChillConfig) extends KryoHadoop(config) {
+    override def newKryo() = {
+      val kryo = super.newKryo()
+      kryo.register(classOf[DateTime], new DateTimeSerializer)
+      kryo
+    }
+  }
+
+}

--- a/core/src/test/scala/au/com/cba/omnia/thermometer/example/CustomSerializersSpec.scala
+++ b/core/src/test/scala/au/com/cba/omnia/thermometer/example/CustomSerializersSpec.scala
@@ -56,8 +56,9 @@ Demonstration of an execution-based ThermometerSpec that relies on a custom Kryo
 
     // pass the register of extra serialziers to the execution job
     val extraConfig =
-      Config.empty ++
-      Map(ChillConfiguredInstantiator.KEY -> classOf[CustomSerializerRegistration].getName)
+      Config
+        .empty
+        .setSerialization(Right(classOf[CustomSerializerRegistration]))
 
     // test pipe of DateTime objects, which can't be serialized properly without a custom
     // serializer

--- a/project/build.scala
+++ b/project/build.scala
@@ -49,9 +49,13 @@ object build extends Build {
       standardSettings
         ++ uniform.project("thermometer", "au.com.cba.omnia.thermometer")
         ++ Seq(
-          libraryDependencies ++=
-            depend.hadoopClasspath ++ depend.hadoop() ++ depend.scalding() ++ depend.testing(configuration = "compile")
-        )
+             libraryDependencies ++=
+                  depend.hadoopClasspath
+               ++ depend.hadoop()
+               ++ depend.scalding()
+               ++ depend.testing(configuration = "compile")
+               ++ depend.time().map(_ % "test")
+           )
   )
 
   lazy val hive = Project(

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.0.2"
+version in ThisBuild := "1.1.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
  - Adds the ability to pass additional configuration to the runner of an
    `Execution`-based test, beyond changing the Scalding `Args`.
  - Adds an example of how this can be used to run an `Execution`-based test
    that requires a custom `Serializer`.