### PR TITLE
Fix in CheckParquet Output

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.1.0"
+version in ThisBuild := "1.1.1"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Ignore the files with Underscore `_`  as Hadoop does, when picked for comparison. 

addressing  Commbank/thermometer#49
