### PR TITLE
Remove unused FieldConversions trait from ExecutionSupport hierarchy.

### DIFF
--- a/core/src/main/scala/au/com/cba/omnia/thermometer/tools/ExecutionSupport.scala
+++ b/core/src/main/scala/au/com/cba/omnia/thermometer/tools/ExecutionSupport.scala
@@ -32,8 +32,8 @@ import au.com.cba.omnia.thermometer.context.Context
 import au.com.cba.omnia.thermometer.fact.Fact
 
 /** Adds testing support for scalding execution monad by setting up a test `Config` and `Mode`.*/
-trait ExecutionSupport extends FieldConversions with HadoopSupport { self: Specification =>
-  /** 
+trait ExecutionSupport extends HadoopSupport { self: Specification =>
+  /**
    * Executes the provided execution.
    * 
    * The provided `Execution` is run in HDFS mode, using supplied arguments and optional additional

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.1.1"
+version in ThisBuild := "1.2.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Inheriting `FieldConversions` via `ThermometerSpec` has resulted in at least one case where otherwise incorrectly typed test code has been allowed to compile.

API version bumped, as there may be code that relies on this behaviour. Upgrading would require those test cases to use a safer alternative, or if nothing else, extend `FieldConversions` directly.