### PR TITLE
The test directories now use standard temp path.

### DIFF
--- a/core/src/main/scala/au/com/cba/omnia/thermometer/tools/HadoopSupport.scala
+++ b/core/src/main/scala/au/com/cba/omnia/thermometer/tools/HadoopSupport.scala
@@ -14,6 +14,8 @@
 
 package au.com.cba.omnia.thermometer.tools
 
+import java.nio.file.{Files, Path => JPath}
+
 import scalaz._, Scalaz._
 
 import org.apache.hadoop.conf.Configuration
@@ -22,14 +24,12 @@ import org.apache.hadoop.mapred.JobConf
 
 /** Adds testing support for Hadoop by creating a `JobConf` with a temporary path.*/
 trait HadoopSupport {
-  lazy val name: String =
-    s"test-${java.util.UUID.randomUUID}"
-
-  lazy val dir: String =
-    s"/tmp/hadoop/${name}/mapred"
+  lazy val testDir: JPath  = Files.createTempDirectory("thermometer-test")
+  lazy val dirPath: JPath  = testDir.resolve("mapred")
+  lazy val dir:     String = dirPath.toString
 
   lazy val jobConf: JobConf = new JobConf <| (conf => {
-    new java.io.File(dir, "data").mkdirs()
+    Files.createDirectory(dirPath.resolve("data"))
     conf.set("user.dir", s"${dir}/user")
     conf.set("jobclient.completion.poll.interval", "10")
     conf.set("cascading.flow.job.pollinginterval", "2")

--- a/hive/src/main/scala/au/com/cba/omnia/thermometer/hive/HiveSupport.scala
+++ b/hive/src/main/scala/au/com/cba/omnia/thermometer/hive/HiveSupport.scala
@@ -29,7 +29,7 @@ import au.com.cba.omnia.thermometer.tools.HadoopSupport
 
 /** Adds testing support for Hive by creating a `HiveConf` with a temporary path.*/
 trait HiveSupport extends HadoopSupport with BeforeEach {
-  lazy val hiveDir: String       = s"/tmp/hadoop/${name}/hive"
+  lazy val hiveDir: String       = testDir.resolve("hive").toString
   lazy val hiveDb: String        = s"$hiveDir/hive_db"
   lazy val hiveWarehouse: String = s"$hiveDir/warehouse"
   lazy val derbyHome: String     = s"$hiveDir/derby"

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.3.0"
+version in ThisBuild := "1.4.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Changes Hadoop support to use `java.nio.file.Files.createTempDirectory`. This changes the path and
names for the temp directories.