### PR TITLE
Include stack trace in message on executesSuccessfully failure

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.4.1"
+version in ThisBuild := "1.4.2"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Previously only `executesOk` would emit a stack trace on failure, but isn't able to be used to return the successful value. This commit factors out common failure code that renders the stack trace in both cases. Also cleans up some trailing whitespace.