### PR TITLE
Do not inspect directories containing only hidden files

### DIFF
--- a/core/src/main/scala/au/com/cba/omnia/thermometer/fact/PathFact.scala
+++ b/core/src/main/scala/au/com/cba/omnia/thermometer/fact/PathFact.scala
@@ -173,6 +173,8 @@ object PathFactoids extends MustThrownExpectations {
 
         RemoteIter(system.listFiles(p, true))
           .filterNot(_.isDirectory)
+          /* Filtering out hidden files so that directories containing only hidden files aren't included */
+          .filter(_.getPath.getName.matches(fileGlob))
           .map(_.getPath.getParent().toString)
           .map(s => s match {
             case pattern(subdir) => subdir

--- a/core/src/test/resources/au/com/cba/omnia/thermometer/example/env3/expected3/cars/1/data1.psv
+++ b/core/src/test/resources/au/com/cba/omnia/thermometer/example/env3/expected3/cars/1/data1.psv
@@ -1,0 +1,2 @@
+Canyonero|1999|NOT_IMP
+Batmobile|1966|NOT_IMP

--- a/core/src/test/resources/au/com/cba/omnia/thermometer/example/env3/expected3/cars/2/data1.psv
+++ b/core/src/test/resources/au/com/cba/omnia/thermometer/example/env3/expected3/cars/2/data1.psv
@@ -1,0 +1,2 @@
+Canyonero|1999|NOT_IMP
+Batmobile|1966|NOT_IMP

--- a/core/src/test/scala/au/com/cba/omnia/thermometer/example/ExecutionSpec.scala
+++ b/core/src/test/scala/au/com/cba/omnia/thermometer/example/ExecutionSpec.scala
@@ -14,6 +14,7 @@
 
 package au.com.cba.omnia.thermometer.example
 
+import java.io.File
 import java.util.Date
 
 import scalaz.effect.IO
@@ -31,9 +32,10 @@ class ExecutionSpec extends ThermometerSpec { def is = s2"""
 Demonstration of ThermometerSpec using Execution monad
 ======================================================
 
-  Verify output using explicit expectations $usingExpectations
-  Verify output using fact api              $usingFacts
-  Verify output against environment         $environment
+  Verify output using explicit expectations           $usingExpectations
+  Verify output using fact api                        $usingFacts
+  Verify output against environment                   $environment
+  Verify output against environment with hidden files $ignoreHidden
 
 """
   val purchaseDate = new Date().toString
@@ -87,6 +89,20 @@ Demonstration of ThermometerSpec using Execution monad
 
     facts(
       path("output") ==> recordsByDirectory(psvReader, psvReader, path("expected"), (r: Car) => {
+        r match { case Car(model, year, _) => model + year + "DUMMY"}
+      })
+    )
+  }
+
+  def ignoreHidden = withEnvironment(path(getClass.getResource("env3").toString)) {
+    executesOk(execution2)
+
+    val hiddenFile = new File(s"$dir/user/output/cars/hidden/_hidden")
+    hiddenFile.getParentFile.mkdirs
+    hiddenFile.createNewFile
+
+    facts(
+      path("output") ==> recordsByDirectory(psvReader, psvReader, path("expected3"), (r: Car) => {
         r match { case Car(model, year, _) => model + year + "DUMMY"}
       })
     )

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.4.3"
+version in ThisBuild := "1.4.4"
 
 localVersionSettings
 


### PR DESCRIPTION
Replacement of https://github.com/CommBank/thermometer/pull/62

`recordsByDirectory` currently fails if a directory containing only hidden files exists. It requires that the 'empty' directory exists in the expected path, but will then fail with `Path <output/hidden/[^_]*> does not exist.`

This PR treats these directories as if they were empty, i.e. not requiring them to exist in the expected path, and not inspecting their contents.