### PR TITLE
Fix bug causing `recordsByDirectory` to fail when file names contain "_"

### DIFF
--- a/core/src/main/scala/au/com/cba/omnia/thermometer/fact/PathFact.scala
+++ b/core/src/main/scala/au/com/cba/omnia/thermometer/fact/PathFact.scala
@@ -173,14 +173,15 @@ object PathFactoids extends MustThrownExpectations {
 
         RemoteIter(system.listFiles(p, true))
           .filterNot(_.isDirectory)
-          /* Filtering out hidden files so that directories containing only hidden files aren't included */
-          .filter(_.getPath.getName.matches(fileGlob))
           .map(_.getPath.getParent().toString)
           .map(s => s match {
             case pattern(subdir) => subdir
           })
           .filter(_ != "")
-          .map(path(_)).toSet
+          .map(path(_))
+          /* Filtering out directories containing only hidden files */
+          .filterNot(subdir => context.glob(p </> subdir </> fileGlob).isEmpty)
+          .toSet
       }
       val actualSubdirs = getRelativeSubdirs(actualPath)
       val expectedSubdirs = getRelativeSubdirs(expectedPath)

--- a/core/src/test/resources/au/com/cba/omnia/thermometer/example/env4/expected4/cars/underscore_file
+++ b/core/src/test/resources/au/com/cba/omnia/thermometer/example/env4/expected4/cars/underscore_file
@@ -1,0 +1,1 @@
+Batmobile|1966|NOT_IMP

--- a/core/src/test/scala/au/com/cba/omnia/thermometer/example/ExecutionSpec.scala
+++ b/core/src/test/scala/au/com/cba/omnia/thermometer/example/ExecutionSpec.scala
@@ -14,7 +14,7 @@
 
 package au.com.cba.omnia.thermometer.example
 
-import java.io.File
+import java.io.{File, PrintWriter}
 import java.util.Date
 
 import scalaz.effect.IO
@@ -32,10 +32,11 @@ class ExecutionSpec extends ThermometerSpec { def is = s2"""
 Demonstration of ThermometerSpec using Execution monad
 ======================================================
 
-  Verify output using explicit expectations           $usingExpectations
-  Verify output using fact api                        $usingFacts
-  Verify output against environment                   $environment
-  Verify output against environment with hidden files $ignoreHidden
+  Verify output using explicit expectations                     $usingExpectations
+  Verify output using fact api                                  $usingFacts
+  Verify output against environment                             $environment
+  Verify output against environment with hidden files           $ignoreHidden
+  Verify output against environment with underscore directories $underscoreFiles
 
 """
   val purchaseDate = new Date().toString
@@ -103,6 +104,22 @@ Demonstration of ThermometerSpec using Execution monad
 
     facts(
       path("output") ==> recordsByDirectory(psvReader, psvReader, path("expected3"), (r: Car) => {
+        r match { case Car(model, year, _) => model + year + "DUMMY"}
+      })
+    )
+  }
+
+  def underscoreFiles = withEnvironment(path(getClass.getResource("env4").toString)) {
+    val file = new File(s"$dir/user/output/cars/underscore_file")
+    file.getParentFile.mkdirs
+    file.createNewFile
+
+    val pw = new PrintWriter(file)
+    pw.append("Batmobile|1966|DUMMY")
+    pw.close()
+
+    facts(
+      path("output") ==> recordsByDirectory(psvReader, psvReader, path("expected4"), (r: Car) => {
         r match { case Car(model, year, _) => model + year + "DUMMY"}
       })
     )

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.4.4"
+version in ThisBuild := "1.4.5"
 
 localVersionSettings
 


### PR DESCRIPTION
Bug was caused by using a file glob as a regex.